### PR TITLE
Add src query toggle for source badges

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -135,6 +135,7 @@ const LAT_STR = q.get('lat'); const LON_STR = q.get('lon');
 const LAT = parseFloat(LAT_STR); const LON = parseFloat(LON_STR);
 const TZ  = 'Europe/Helsinki';
 const DBG = q.has('dbg');
+const SHOW_SOURCE_BADGES = DBG || q.has('src');
 const tag = s => DBG ? ` <span class="soft" style="font-size:12px">${s}</span>` : '';
 
 /* --------- erikoisotsikot --------- */
@@ -724,7 +725,7 @@ function selectDescription({ nowcastText, harmonieText, expectedNowcast=false })
 }
 
 function buildSourceBadge({ source, expectedNowcast=false, fallbackFromNowcast=false }){
-  if (!expectedNowcast) return '';
+  if (!SHOW_SOURCE_BADGES || !expectedNowcast) return '';
   if (source === 'nowcast'){
     return '<span class="sourceBadge sourceBadgeNc">NC</span>';
   }


### PR DESCRIPTION
## Summary
- add a SHOW_SOURCE_BADGES flag that also considers the src query parameter
- show source badges only when the flag is active and a nowcast was expected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6dbf9f05883299778a78c3b710632