### PR TITLE
Adjust sunrise and sunset label phrasing

### DIFF
--- a/saa_yr.html
+++ b/saa_yr.html
@@ -74,6 +74,18 @@
   function fmt(d, opts){ return d.toLocaleString('fi-FI', Object.assign({timeZone:TZ}, opts||{})); }
   function fmtH(d){ return fmt(d, {hour:'numeric'}); }
   function fmtHM(d){ return fmt(d, {hour:'numeric', minute:'2-digit'}); }
+  function formatSunEventLabel(date, type){
+    if (!(date instanceof Date)) return null;
+    var hhmm = fmtHM(date);
+    if (!hhmm) return null;
+    var mins = date.getMinutes();
+    var isRise = type === 'rise';
+    if (typeof mins === 'number' && mins < 30){
+      return (isRise ? 'auringonnousu ' : 'auringonlasku ') + hhmm;
+    }
+    var prefix = isRise ? 'Aurinko nousee ' : 'Aurinko laskee ';
+    return prefix + hhmm + '.';
+  }
 
   // VAKAA paikallisen ajan olio MET:n ISO-UTC:stä (ei toLocaleString-parsausta)
   function localFromUtc(iso){
@@ -425,7 +437,8 @@
             // tunnisteet
             var tags=[];
             if (tw.sunEvent && isFinite(tw.sunEvent.at.getTime())){
-              tags.push((tw.sunEvent.type==='set'?'auringonlasku':'auringonnousu')+' '+fmtHM(tw.sunEvent.at));
+              var sunLabel = formatSunEventLabel(tw.sunEvent.at, tw.sunEvent.type);
+              if (sunLabel) tags.push(sunLabel);
             } else if (tw.withinChange && isFinite(tw.withinChange.at.getTime())){
               var lbl = nextLabelFor(tw.withinChange.to);
               if (lbl) tags.push(lbl+' '+fmtHM(tw.withinChange.at));

--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -630,12 +630,23 @@ function formatSmallTag(entry){
   return `<span class="${cls}"${attrStr}>${body}</span>`;
 }
 
+function baseSunEventText(at, type){
+  if (!(at instanceof Date)) return null;
+  const hhmm = fmtHM(at);
+  if (!hhmm) return null;
+  const mins = at.getMinutes();
+  const isRise = type === 'rise';
+  if (typeof mins === 'number' && mins < 30){
+    return isRise ? `auringonnousu ${hhmm}` : `auringonlasku ${hhmm}`;
+  }
+  const verb = isRise ? 'Aurinko nousee' : 'Aurinko laskee';
+  return `${verb} ${hhmm}.`;
+}
+
 function formatSunEventTag(sunEvent){
   if (!sunEvent || !(sunEvent.at instanceof Date)) return null;
-  const hhmm = fmtHM(sunEvent.at);
-  if (!hhmm) return null;
-  const isRise = sunEvent.type === 'rise';
-  const sentence = isRise ? `Aurinko nousee ${hhmm}` : `Aurinko laskee ${hhmm}`;
+  const sentence = baseSunEventText(sunEvent.at, sunEvent.type);
+  if (!sentence) return null;
   return { text: sentence, italic: true, prefix: false, preserveCase: true };
 }
 

--- a/tusinapuuska.html
+++ b/tusinapuuska.html
@@ -386,13 +386,15 @@ function formatSmallTag(entry){
   if (!entry) return '';
   let text = '';
   let italic = false;
+  let preserveCase = false;
   if (typeof entry === 'string'){ text = entry; }
   else if (typeof entry === 'object' && entry){
     text = entry.text || '';
     italic = !!entry.italic;
+    preserveCase = !!entry.preserveCase;
   }
   if (!text) return '';
-  let body = text.toLocaleLowerCase('fi-FI');
+  let body = preserveCase ? text : text.toLocaleLowerCase('fi-FI');
   if (italic) body = `<em>${body}</em>`;
   return `<span class="mini">${body}</span>`;
 }
@@ -408,12 +410,26 @@ function formatHourRange(hourStart){
   return `${from}–${to}`;
 }
 
+function baseSunEventText(at, type){
+  if (!(at instanceof Date)) return null;
+  const hhmm = fmtHM(at);
+  if (!hhmm) return null;
+  const mins = at.getMinutes();
+  const isRise = type === 'rise';
+  if (typeof mins === 'number' && mins < 30){
+    return isRise ? `auringonnousu ${hhmm}` : `auringonlasku ${hhmm}`;
+  }
+  const verb = isRise ? 'Aurinko nousee' : 'Aurinko laskee';
+  return `${verb} ${hhmm}.`;
+}
+
 function formatSunEventTag(sunEvent, { hourStart, twilightMain, phaseMain }){
   if (!sunEvent || !(sunEvent.at instanceof Date)) return null;
   const hhmm = fmtHM(sunEvent.at);
   if (!hhmm) return null;
   const isRise = sunEvent.type === 'rise';
   let text = null;
+  let preserveCase = false;
   if (
     !isRise &&
     twilightMain &&
@@ -427,14 +443,27 @@ function formatSunEventTag(sunEvent, { hourStart, twilightMain, phaseMain }){
     }
   }
   if (!text){
-    if (isRise){
-      const range = hourStart instanceof Date ? formatHourRange(hourStart) : null;
-      text = range ? `auringonnousu ${hhmm} (klo ${range})` : `auringonnousu ${hhmm}`;
-    } else {
-      text = `auringonlasku ${hhmm}`;
+    const base = baseSunEventText(sunEvent.at, sunEvent.type);
+    if (base){
+      preserveCase = true;
+      if (isRise){
+        const range = hourStart instanceof Date ? formatHourRange(hourStart) : null;
+        if (range){
+          if (base.endsWith('.')){
+            text = `${base.slice(0, -1)} (klo ${range}).`;
+          } else {
+            text = `${base} (klo ${range})`;
+          }
+        } else {
+          text = base;
+        }
+      } else {
+        text = base;
+      }
     }
   }
-  return { text, italic: false };
+  if (!text) return null;
+  return { text, italic: false, preserveCase };
 }
 
 function isBlueTone(text){

--- a/tusinasaa.html
+++ b/tusinasaa.html
@@ -607,12 +607,23 @@ function formatSmallTag(entry){
   return `<span class="${cls}"${attrStr}>${body}</span>`;
 }
 
+function baseSunEventText(at, type){
+  if (!(at instanceof Date)) return null;
+  const hhmm = fmtHM(at);
+  if (!hhmm) return null;
+  const mins = at.getMinutes();
+  const isRise = type === 'rise';
+  if (typeof mins === 'number' && mins < 30){
+    return isRise ? `auringonnousu ${hhmm}` : `auringonlasku ${hhmm}`;
+  }
+  const verb = isRise ? 'Aurinko nousee' : 'Aurinko laskee';
+  return `${verb} ${hhmm}.`;
+}
+
 function formatSunEventTag(sunEvent){
   if (!sunEvent || !(sunEvent.at instanceof Date)) return null;
-  const hhmm = fmtHM(sunEvent.at);
-  if (!hhmm) return null;
-  const isRise = sunEvent.type === 'rise';
-  const sentence = isRise ? `Aurinko nousee ${hhmm}` : `Aurinko laskee ${hhmm}`;
+  const sentence = baseSunEventText(sunEvent.at, sunEvent.type);
+  if (!sentence) return null;
   return { text: sentence, italic: true, prefix: false, preserveCase: true };
 }
 


### PR DESCRIPTION
## Summary
- update sunrise and sunset tag formatting so times before :30 use the short lowercase form and later events use the capitalized sentence with a period in tusinasaa.html and tusinapaja.html
- allow tusinapuuska.html to preserve casing for sunrise and sunset tags while adopting the same minute-sensitive phrasing
- switch saa_yr.html to the shared sunrise and sunset wording helper for consistent output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6df8501348329b4c2ee82a05b92cd