### PR TITLE
Remove custom twilight text color in workshop view

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -24,7 +24,6 @@
     letter-spacing:.6px;
     font-style:italic;
     font-weight:350;
-    color:#b5bfc8;
     font-variation-settings:'wght' 350;
   }
   @supports not (font-weight: 350){


### PR DESCRIPTION
## Summary
- remove the hard-coded color override from the twilightMainText span so twilight descriptions inherit the standard gray

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e52feaf48329a549b7529a7481c0