### PR TITLE
Normalize säkkipimeä transition messaging

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -493,7 +493,7 @@ const TWILIGHT_PHASES = new Set(['civil','nautical','astronomical','night']);
 function nextLabelFor(toPhase){
   if (toPhase==='nautical') return 'vaihtuu nauttiseksi';
   if (toPhase==='astronomical') return 'astronominen hämärä';
-  if (toPhase==='night') return '-> säkkipimeäksi';
+  if (toPhase==='night') return 'säkkipimeä';
   if (toPhase==='civil') return 'porvarillinen alkaa';
   return null;
 }
@@ -920,7 +920,9 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
       const fromPhase = tw.withinChange.from || tw.phase;
       let text = `...${label} ${hhmm}`;
       let dittoEllipsis = false;
-      if (!precipish){
+      if (toPhase === 'night'){
+        text = `säkkipimeä ${hhmm}`;
+      } else if (!precipish){
         if (toPhase === 'astronomical' && fromPhase === 'night'){
           text = `astronominen hämärä ${hhmm}`;
         } else if (typeof minutes === 'number' && minutes >= 30){
@@ -944,7 +946,9 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
       if (dittoEllipsis) entry.dittoEllipsis = true;
       tags.push(entry);
     } else if (label){
-      tags.push({ text: `...${label} ${fmtHM(tw.withinChange.at)}`, italic: true });
+      const base = `...${label} ${fmtHM(tw.withinChange.at)}`;
+      const text = tw.withinChange?.to === 'night' ? base.replace(/^\.\.\./, '').trimStart() : base;
+      tags.push({ text, italic: true });
     }
     if (
       label &&

--- a/tusinapuuska.html
+++ b/tusinapuuska.html
@@ -325,7 +325,7 @@ function phaseLabel(phase){
 function nextLabelFor(toPhase){
   if (toPhase==='nautical') return 'vaihtuu nauttiseksi';
   if (toPhase==='astronomical') return 'vaihtuu astronomiseksi hämäräksi';
-  if (toPhase==='night') return 'säkkipimeäksi';
+  if (toPhase==='night') return 'säkkipimeä';
   if (toPhase==='civil') return 'porvarillinen alkaa';
   return null;
 }

--- a/tusinasaa.html
+++ b/tusinasaa.html
@@ -471,7 +471,7 @@ const TWILIGHT_PHASES = new Set(['civil','nautical','astronomical','night']);
 function nextLabelFor(toPhase){
   if (toPhase==='nautical') return 'vaihtuu nauttiseksi';
   if (toPhase==='astronomical') return 'astronominen hämärä';
-  if (toPhase==='night') return '-> säkkipimeäksi';
+  if (toPhase==='night') return 'säkkipimeä';
   if (toPhase==='civil') return 'porvarillinen alkaa';
   return null;
 }
@@ -870,7 +870,9 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
       const isTwilightPhase = phase => phase === 'civil' || phase === 'nautical' || phase === 'astronomical';
       let text = `...${label} ${hhmm}`;
       let dittoEllipsis = false;
-      if (!precipish){
+      if (toPhase === 'night'){
+        text = `säkkipimeä ${hhmm}`;
+      } else if (!precipish){
         if (toPhase === 'astronomical' && fromPhase === 'night'){
           text = `astronominen hämärä ${hhmm}`;
         } else if (typeof minutes === 'number' && minutes >= 30){
@@ -890,7 +892,9 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
       if (dittoEllipsis) entry.dittoEllipsis = true;
       tags.push(entry);
     } else if (label){
-      tags.push({ text: `...${label} ${fmtHM(tw.withinChange.at)}`, italic: true });
+      const base = `...${label} ${fmtHM(tw.withinChange.at)}`;
+      const text = tw.withinChange?.to === 'night' ? base.replace(/^\.\.\./, '').trimStart() : base;
+      tags.push({ text, italic: true });
     }
     if (
       label &&


### PR DESCRIPTION
## Summary
- adjust the twilight transition helper to describe the säkkipimeä phase without arrows or translative forms
- ensure night-phase change annotations render without a leading ellipsis in the hourly tags
- align the auxiliary tusinapuuska helper with the updated säkkipimeä wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6f02aef248329b6e8c477ed40faa6