### PR TITLE
Document capitalization follow-up tasks for workshop mode

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -99,6 +99,18 @@
 
 <script>
 /* --------- perusinfra & virheet näkyviin --------- */
+/* --------- tonttien työlista (palaverin jatkotoimet) --------- */
+/*
+1. Yhtenäistä pääselitteen kirjainkoko niin, että `capitalizeDayDescription`
+   ajetaan kaikissa vaiheissa ilman päivä-vaiherajausta, ja varmista samalla,
+   ettei tyhjät tai HTML-elementillä alkavat selitteet muutu.
+2. Selvitä nousua edeltävien kuivien tuntien käsittely: kun hämärävaihe ei enää
+   päädy päätekstiksi, varmista että kuivan sään kuvaus nostaa ensimmäisen
+   kirjaimen isoksi ja ettei hämärän CSS-yläsuuraus laukea vahingossa.
+3. Päivitä testisuunnitelma kattamaan sumu-, sade- ja kuivatapaukset sekä
+   aurinkotapahtumien molemmat kieliasut, jotta kirjaimiston poikkeamat eivät
+   palaa jatkokehityksessä.
+*/
 const out = document.getElementById('out');
 window.addEventListener('error', e => {
   const msg = (e && e.message) ? e.message : String(e);


### PR DESCRIPTION
## Summary
- add a workshop to-do list that delegates capitalization follow-up work to the team

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d706476f9883298039a94fbbb2500d