### PR TITLE
Remove legacy sumupaininta reference

### DIFF
--- a/tusinasaa.html
+++ b/tusinasaa.html
@@ -633,8 +633,8 @@ function buildDescriptionHtml({ main, tags, extra }){
   let extraHtml = extra || '';
   if (typeof safeMain === 'string'){
     const normalizedMain = safeMain.replace(/<[^>]*>/g, '').trim().toUpperCase();
-    if (normalizedMain === 'MIST!' && !/siis sumua\. siis sumupainintaa\./i.test(extraHtml)){
-      extraHtml += ` <span class="mini">siis sumua. siis sumupainintaa.</span>`;
+    if (normalizedMain === 'MIST!' && !/siis sumua\./i.test(extraHtml)){
+      extraHtml += ` <span class="mini">siis sumua.</span>`;
     }
   }
   const formattedTags = tagList.map(formatSmallTag);


### PR DESCRIPTION
## Summary
- remove the legacy "sumupaininta" wording from the fog description helper in tusinasaa to keep copy consistent with current terminology

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7165247248329b825ff45a358b923