### PR TITLE
Remove mist legacy references

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -1036,7 +1036,7 @@ function isWetDescriptor(text, opts = {}){
   if (!text) return false;
   const low = text.toLowerCase();
   return [
-    'ripsii', 'satelee', 'kaatosad', 'ränt', 'hiutale', 'pyry', 'rake', 'mist',
+    'ripsii', 'satelee', 'kaatosad', 'ränt', 'hiutale', 'pyry', 'rake',
     'kuuro', 'ukkos', 'tihkuu', 'sadetta', 'märkä', 'lunta', 'sumu'
   ].some(w => low.includes(w));
 }
@@ -1061,7 +1061,7 @@ function analyzeFogDescriptor({ text, source }){
   const raw = (typeof text === 'string') ? text.trim() : '';
   if (!raw) return { isFog: false, baseText: raw, displayText: raw };
   const normalized = raw.toLocaleLowerCase('fi-FI');
-  if (normalized === 'mist!' || normalized === 'sumua' || normalized === 'sumu'){
+  if (normalized === 'sumua' || normalized === 'sumu'){
     let displayText = 'sumua';
     if (source === 'harmonie') displayText = 'Näkyvyys: mahdollinen';
     else if (source === 'nowcast') displayText = 'Näkyvyys: ei ole';

--- a/tusinapuuska.html
+++ b/tusinapuuska.html
@@ -492,7 +492,7 @@ function isWetDescriptor(text){
   if (!text) return false;
   const low = text.toLowerCase();
   return [
-    'ripsii', 'satelee', 'kaatosad', 'ränt', 'hiutale', 'pyry', 'rake', 'mist',
+    'ripsii', 'satelee', 'kaatosad', 'ränt', 'hiutale', 'pyry', 'rake',
     'kuuro', 'ukkos', 'tihkuu', 'sadetta', 'märkä', 'lunta', 'sumu'
   ].some(w => low.includes(w));
 }

--- a/tusinasaa.html
+++ b/tusinasaa.html
@@ -691,7 +691,7 @@ function isWetDescriptor(text){
   if (!text) return false;
   const low = text.toLowerCase();
   return [
-    'ripsii', 'satelee', 'kaatosad', 'ränt', 'hiutale', 'pyry', 'rake', 'mist',
+    'ripsii', 'satelee', 'kaatosad', 'ränt', 'hiutale', 'pyry', 'rake',
     'kuuro', 'ukkos', 'tihkuu', 'sadetta', 'märkä', 'lunta', 'sumu'
   ].some(w => low.includes(w));
 }


### PR DESCRIPTION
## Summary
- remove the obsolete "mist" marker from precipitation keyword lists
- simplify fog descriptor normalization by dropping the unused "mist!" case

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d716f919448329abebdf5c63f9955f