### PR TITLE
Normalize description capitalization across phases

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -1212,9 +1212,7 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
 
   const phaseMain = phaseLabel(tw.phase);
   tintedMain = maybeApplyGoldTint(baseText, tw);
-  if (tw.phase === 'day'){
-    tintedMain = capitalizeDayDescription(tintedMain);
-  }
+  tintedMain = capitalizeDayDescription(tintedMain);
   let main = tintedMain;
 
   const twilightMainAllowed = allowTwilightAsMain(tw);
@@ -1331,9 +1329,7 @@ function maybeApplyTwilightPrecipOverride({
   let main = (typeof baseDesc === 'string') ? baseDesc : '';
   if (main && main !== '–'){
     let tinted = maybeApplyGoldTint(main, tw);
-    if (tw && tw.phase === 'day'){
-      tinted = capitalizeDayDescription(tinted);
-    }
+    tinted = capitalizeDayDescription(tinted);
     main = tinted;
   }
 


### PR DESCRIPTION
## Summary
- always run description capitalization after applying twilight tinting so dry descriptors start with uppercase even before sunrise
- ensure precipitation override path also capitalizes descriptions regardless of phase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d717aeeedc8329a8170b28b3d29646