### PR TITLE
Add light-mode theme that follows system preference

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -7,17 +7,62 @@
 <title>TUSINASÄÄ 12</title>
 <!-- ohjelman leima: TUSINASÄÄ 12 versio 1.1.1 -->
 <style>
-  :root { color-scheme: dark; }
+  :root {
+    color-scheme: dark;
+    --color-bg: #000;
+    --color-text: #e8e8e8;
+    --color-page-title: #9aa6b0;
+    --color-mini: #7f8a93;
+    --color-mini-strong: #e8e8e8;
+    --color-muted: #74808a;
+    --color-soft: #7f8a93;
+    --color-border: #2a2a2a;
+    --color-border-strong: #1c1c1c;
+    --color-badge-default: #7f8a93;
+    --color-badge-nc: #9fb6ff;
+    --color-badge-nc-border: #35415a;
+    --color-badge-hrm: #b7b7b7;
+    --color-badge-hrm-border: #3a3a3a;
+    --color-badge-fallback: #d9b27d;
+    --color-badge-fallback-border: #5a4528;
+    --color-error: #ff6b6b;
+    --color-error-note: #888;
+    --color-contradiction: #a65050;
+  }
+  @media (prefers-color-scheme: light){
+    :root {
+      color-scheme: light;
+      --color-bg: #f7f8fa;
+      --color-text: #1c1f22;
+      --color-page-title: #5a6570;
+      --color-mini: #646f78;
+      --color-mini-strong: #1c1f22;
+      --color-muted: #596470;
+      --color-soft: #68737e;
+      --color-border: #d5d9df;
+      --color-border-strong: #c5c9cf;
+      --color-badge-default: #68737e;
+      --color-badge-nc: #4a5dab;
+      --color-badge-nc-border: #a8b4cf;
+      --color-badge-hrm: #555b60;
+      --color-badge-hrm-border: #c3c6ca;
+      --color-badge-fallback: #8d6c3f;
+      --color-badge-fallback-border: #d8c2a3;
+      --color-error: #c34242;
+      --color-error-note: #666;
+      --color-contradiction: #c46464;
+    }
+  }
   html,body{height:100%}
   body{
-    margin:0; padding:22px 14px 24px; background:#000; color:#e8e8e8;
+    margin:0; padding:22px 14px 24px; background:var(--color-bg); color:var(--color-text);
     font:17px/1.5 Arial,system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,sans-serif;
     -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
     font-synthesis:none;
   }
-  .pageTitle{ font-weight:700; font-size:15px; letter-spacing:.4px; color:#9aa6b0;
+  .pageTitle{ font-weight:700; font-size:15px; letter-spacing:.4px; color:var(--color-page-title);
     text-transform:uppercase; margin:0 0 4px 0 }
-  .mini{ color:#7f8a93; font-size:12px; letter-spacing:.3px; line-height:1.2 }
+  .mini{ color:var(--color-mini); font-size:12px; letter-spacing:.3px; line-height:1.2 }
   .miniTwilight{ font-style:italic; font-weight:300 }
   .twilightMainText{
     font-size:13px;
@@ -37,51 +82,51 @@
     display:inline-block;
     width:var(--mini-ellipsis-width, 10px);
   }
-  .miniW{ color:#e8e8e8; font-size:12px; letter-spacing:.3px; line-height:1.2 }
+  .miniW{ color:var(--color-mini-strong); font-size:12px; letter-spacing:.3px; line-height:1.2 }
   .caps{ text-transform:uppercase; letter-spacing:.5px }
-  .list{ border-top:1px solid #2a2a2a; margin-top:6px; }
+  .list{ border-top:1px solid var(--color-border); margin-top:6px; }
   .sourceBadge{
     display:inline-block;
     margin-left:6px;
     padding:1px 5px 0;
-    border:1px solid #2a2a2a;
+    border:1px solid var(--color-border);
     border-radius:3px;
     font-size:11px;
     letter-spacing:.3px;
     text-transform:uppercase;
-    color:#7f8a93;
+    color:var(--color-badge-default);
   }
-  .sourceBadgeNc{ color:#9fb6ff; border-color:#35415a; }
-  .sourceBadgeHrm{ color:#b7b7b7; border-color:#3a3a3a; }
-  .sourceBadgeFallback{ color:#d9b27d; border-color:#5a4528; }
+  .sourceBadgeNc{ color:var(--color-badge-nc); border-color:var(--color-badge-nc-border); }
+  .sourceBadgeHrm{ color:var(--color-badge-hrm); border-color:var(--color-badge-hrm-border); }
+  .sourceBadgeFallback{ color:var(--color-badge-fallback); border-color:var(--color-badge-fallback-border); }
   .hdr{
-    color:#6b7580; font-size:12px; letter-spacing:.3px; margin:6px 0 4px 0;
+    color:var(--color-muted); font-size:12px; letter-spacing:.3px; margin:6px 0 4px 0;
     display:grid; grid-template-columns:54px 34px 1fr 70px 70px; align-items:end; justify-items:center;
     gap:8px;
   }
-  .hdr > div:first-child{ border-right:1px solid #2a2a2a; padding-right:10px; margin-right:4px }
+  .hdr > div:first-child{ border-right:1px solid var(--color-border); padding-right:10px; margin-right:4px }
   .hdr div:nth-child(-n+3){ justify-self:start; text-align:left }
   .hdr div:nth-child(4){ justify-self:center; text-align:center; transform:translateX(-1px) }
   .hdr div:nth-child(5){ justify-self:start; text-align:left; font-size:11px }
   .row{
     display:grid; grid-template-columns:54px 34px 1fr 70px 70px;
-    gap:8px; padding:6px 0; border-bottom:1px solid #1c1c1c; align-items:center;
+    gap:8px; padding:6px 0; border-bottom:1px solid var(--color-border-strong); align-items:center;
     min-height:54px;
   }
-  .row > div:first-child{ border-right:1px solid #2a2a2a; padding-right:10px; margin-right:4px; text-align:right }
-  .muted{ color:#74808a } .soft{ color:#7f8a93 }
-  .cell{ color:#e8e8e8 }
-  .cell.soft{ color:#7f8a93 }
-  .desc{ color:#7f8a93 }
-  .descWhite{ color:#e8e8e8 }
-  .contradictionMain{ text-decoration:line-through; text-decoration-thickness:1.1px; text-decoration-color:#a65050; text-decoration-skip-ink:auto }
-  .contradictionNote{ display:block; font-size:9px; font-style:italic; color:#888; letter-spacing:.2px; margin-top:2px }
+  .row > div:first-child{ border-right:1px solid var(--color-border); padding-right:10px; margin-right:4px; text-align:right }
+  .muted{ color:var(--color-muted) } .soft{ color:var(--color-soft) }
+  .cell{ color:var(--color-text) }
+  .cell.soft{ color:var(--color-soft) }
+  .desc{ color:var(--color-soft) }
+  .descWhite{ color:var(--color-mini-strong) }
+  .contradictionMain{ text-decoration:line-through; text-decoration-thickness:1.1px; text-decoration-color:var(--color-contradiction); text-decoration-skip-ink:auto }
+  .contradictionNote{ display:block; font-size:9px; font-style:italic; color:var(--color-error-note); letter-spacing:.2px; margin-top:2px }
   .row > div:nth-child(4){ text-align:center }
   .row > div:nth-child(5){ font-size:16px }
   .desc .ditto{ display:inline } .ditto{ color:inherit }
   .dash{ text-align:center }
   .windDir{ display:block; margin-top:2px; font-size:11px }
-  .err{ color:#ff6b6b; white-space:pre-wrap; font-size:14px; margin-top:8px }
+  .err{ color:var(--color-error); white-space:pre-wrap; font-size:14px; margin-top:8px }
 </style>
 </head>
 <body>
@@ -1408,7 +1453,7 @@ function windCell(mean, gust, dirDeg, { meanSource='harmonie', gustSource=null }
   if (gOk && gustV >= 15){
     const gustFmt = formatWindSpeed(gustV);
     if (gustFmt != null){
-      gustTxt = ` (<em style="color:#e8e8e8">${gustFmt}</em>)`;
+      gustTxt = ` (<em style="color:var(--color-mini-strong)">${gustFmt}</em>)`;
     }
     highlight = true;
   }


### PR DESCRIPTION
## Summary
- introduce theme variables for Tusina workshop view
- add a light color palette that follows the browser prefers-color-scheme setting
- ensure inline gust highlights respect the chosen theme

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7bfe444c0832989de07931798c8f4