### PR TITLE
Add Heinjoki preset title to Tusinasää pages

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -235,10 +235,27 @@ const TZ = timeZone;
 
 /* --------- erikoisotsikot --------- */
 const pageTitle = document.getElementById('pageTitle');
-if (LAT_STR === '60.3281' && LON_STR === '25.0551'){
-  pageTitle.textContent = 'TUSINASÄÄ 12 · ASOLA'; pageTitle.style.display = '';
-} else if (LAT_STR === '60.1562' && LON_STR === '24.7767'){
-  pageTitle.textContent = 'TUSINASÄÄ 12 · RANTAKOTO'; pageTitle.style.display = '';
+const SPECIAL_TITLES = {
+  '60.3281,25.0551': 'TUSINASÄÄ 12 · ASOLA',
+  '60.1562,24.7767': 'TUSINASÄÄ 12 · RANTAKOTO',
+  '60.2038,24.8030': 'TUSINASÄÄ 12 · HEINJOKI',
+  '60.1620,24.8791': 'TUSINASÄÄ 12 · HEINJOKI',
+};
+let specialTitle = null;
+if (LAT_STR && LON_STR){
+  specialTitle = SPECIAL_TITLES[`${LAT_STR},${LON_STR}`] || null;
+  if (!specialTitle){
+    const latNum = Number(LAT_STR);
+    const lonNum = Number(LON_STR);
+    if (Number.isFinite(latNum) && Number.isFinite(lonNum)){
+      const normalizedKey = `${latNum.toFixed(4)},${lonNum.toFixed(4)}`;
+      specialTitle = SPECIAL_TITLES[normalizedKey] || null;
+    }
+  }
+}
+if (specialTitle){
+  pageTitle.textContent = specialTitle;
+  pageTitle.style.display = '';
 }
 
 /* --------- aikaformatit --------- */

--- a/tusinapuuska.html
+++ b/tusinapuuska.html
@@ -70,10 +70,27 @@ const tag = s => DBG ? ` <span class="soft" style="font-size:12px">${s}</span>` 
 
 /* --------- erikoisotsikot --------- */
 const pageTitle = document.getElementById('pageTitle');
-if (LAT_STR === '60.3281' && LON_STR === '25.0551'){
-  pageTitle.textContent = 'TUSINASÄÄ 12 · ASOLA'; pageTitle.style.display = '';
-} else if (LAT_STR === '60.1562' && LON_STR === '24.7767'){
-  pageTitle.textContent = 'TUSINASÄÄ 12 · RANTAKOTO'; pageTitle.style.display = '';
+const SPECIAL_TITLES = {
+  '60.3281,25.0551': 'TUSINASÄÄ 12 · ASOLA',
+  '60.1562,24.7767': 'TUSINASÄÄ 12 · RANTAKOTO',
+  '60.2038,24.8030': 'TUSINASÄÄ 12 · HEINJOKI',
+  '60.1620,24.8791': 'TUSINASÄÄ 12 · HEINJOKI',
+};
+let specialTitle = null;
+if (LAT_STR && LON_STR){
+  specialTitle = SPECIAL_TITLES[`${LAT_STR},${LON_STR}`] || null;
+  if (!specialTitle){
+    const latNum = Number(LAT_STR);
+    const lonNum = Number(LON_STR);
+    if (Number.isFinite(latNum) && Number.isFinite(lonNum)){
+      const normalizedKey = `${latNum.toFixed(4)},${lonNum.toFixed(4)}`;
+      specialTitle = SPECIAL_TITLES[normalizedKey] || null;
+    }
+  }
+}
+if (specialTitle){
+  pageTitle.textContent = specialTitle;
+  pageTitle.style.display = '';
 }
 
 /* --------- aikaformatit --------- */

--- a/tusinasaa.html
+++ b/tusinasaa.html
@@ -190,10 +190,27 @@ const TZ = timeZone;
 
 /* --------- erikoisotsikot --------- */
 const pageTitle = document.getElementById('pageTitle');
-if (LAT_STR === '60.3281' && LON_STR === '25.0551'){
-  pageTitle.textContent = 'TUSINASÄÄ 12 · ASOLA'; pageTitle.style.display = '';
-} else if (LAT_STR === '60.1562' && LON_STR === '24.7767'){
-  pageTitle.textContent = 'TUSINASÄÄ 12 · RANTAKOTO'; pageTitle.style.display = '';
+const SPECIAL_TITLES = {
+  '60.3281,25.0551': 'TUSINASÄÄ 12 · ASOLA',
+  '60.1562,24.7767': 'TUSINASÄÄ 12 · RANTAKOTO',
+  '60.2038,24.8030': 'TUSINASÄÄ 12 · HEINJOKI',
+  '60.1620,24.8791': 'TUSINASÄÄ 12 · HEINJOKI',
+};
+let specialTitle = null;
+if (LAT_STR && LON_STR){
+  specialTitle = SPECIAL_TITLES[`${LAT_STR},${LON_STR}`] || null;
+  if (!specialTitle){
+    const latNum = Number(LAT_STR);
+    const lonNum = Number(LON_STR);
+    if (Number.isFinite(latNum) && Number.isFinite(lonNum)){
+      const normalizedKey = `${latNum.toFixed(4)},${lonNum.toFixed(4)}`;
+      specialTitle = SPECIAL_TITLES[normalizedKey] || null;
+    }
+  }
+}
+if (specialTitle){
+  pageTitle.textContent = specialTitle;
+  pageTitle.style.display = '';
 }
 
 /* --------- aikaformatit --------- */


### PR DESCRIPTION
## Summary
- add Heinjoki coordinates to the preset title list used in tusinasää views
- normalize coordinate comparison so the custom title works even when trailing zeros differ

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d834c552d883298ae97d48bd864dae