### PR TITLE
Fix worker CORS handling

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -1,7 +1,10 @@
-function withCORS(res, origin = '*') {
-  res.headers.set('access-control-allow-origin', origin);
-  res.headers.set('access-control-allow-methods', 'GET,OPTIONS');
-  res.headers.set('access-control-allow-headers', '*');
+function withCORS(res, { origin = '*', requestHeaders } = {}) {
+  res.headers.set('Access-Control-Allow-Origin', origin);
+  res.headers.set('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  if (requestHeaders) {
+    res.headers.set('Access-Control-Allow-Headers', requestHeaders);
+  }
+  res.headers.set('Vary', 'Origin');
   if (!res.headers.has('cache-control')) res.headers.set('cache-control', 'no-store');
   return res;
 }
@@ -9,28 +12,30 @@ function withCORS(res, origin = '*') {
 export default {
   async fetch(req, env) {
     const url = new URL(req.url);
+    const origin = req.headers.get('Origin') || '*';
+    const requestHeaders = req.headers.get('Access-Control-Request-Headers');
 
     // Preflight
     if (req.method === 'OPTIONS') {
-      return withCORS(new Response(null, { status: 204 }));
+      return withCORS(new Response(null, { status: 204 }), { origin, requestHeaders });
     }
 
     if (url.pathname !== '/api/loc') {
-      return withCORS(new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } }));
+      return withCORS(new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } }), { origin, requestHeaders });
     }
 
     const t = url.searchParams.get('t') || url.searchParams.get('token');
     if (!t) {
-      return withCORS(new Response('Missing token', { status: 400, headers: { 'content-type': 'text/plain' } }));
+      return withCORS(new Response('Missing token', { status: 400, headers: { 'content-type': 'text/plain' } }), { origin, requestHeaders });
     }
 
     const item = await env.LOCATIONS.get(t, { type: 'json' });
     if (!item) {
-      return withCORS(new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } }));
+      return withCORS(new Response('Not found', { status: 404, headers: { 'content-type': 'text/plain' } }), { origin, requestHeaders });
     }
 
     return withCORS(new Response(JSON.stringify(item), {
       headers: { 'content-type': 'application/json', 'cache-control': 'no-store' }
-    }));
+    }), { origin, requestHeaders });
   }
 }


### PR DESCRIPTION
## Summary
- update the `withCORS` helper to take an options object and set the required CORS headers
- forward request origin and requested headers so preflight responses include the expected values

## Testing
- `wrangler deploy` *(fails: wrangler not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f1f3b490832983135128b4df1178