### PR TITLE
Fix tz lookup loading and harden location decoding

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -7,14 +7,28 @@
   const searchFallback = (!hash && location.search && location.search.startsWith('?')) ? location.search.slice(1) : '';
   const P = new URLSearchParams(hash || searchFallback);
 
-  const T = P.get('t') || P.get('token');
-  const K = P.get('k') || P.get('key');
+  function requireParam(value, name){
+    if (typeof value !== 'string' || value.length === 0){
+      throw new Error(`Puuttuva tai virheellinen parametri: ${name}`);
+    }
+    return value;
+  }
+
+  const T = requireParam((() => {
+    const primary = P.get('t');
+    if (typeof primary === 'string' && primary.length > 0) return primary;
+    const fallback = P.get('token');
+    return fallback;
+  })(), 't');
+  const K = requireParam((() => {
+    const primary = P.get('k');
+    if (typeof primary === 'string' && primary.length > 0) return primary;
+    const fallback = P.get('key');
+    return fallback;
+  })(), 'k');
 
   console.log('DEBUG href=', location.href);
   console.log('DEBUG T=', T, 'K=', K);
-
-  if (!T) { throw new Error('Sijaintitokenia ei löytynyt.'); }
-  if (!K) { throw new Error('Salausavain (k) puuttuu.'); }
 
   const API_BASE = 'https://tusinasaa-worker.ollijuutilainen.workers.dev';
 
@@ -24,9 +38,16 @@
     .catch(err => console.error('Haku epäonnistui:', err));
 
   function b64uToBytes(s){
-    s = s.replace(/-/g,'+').replace(/_/g,'/'); const pad = (4 - s.length % 4) % 4;
-    s += '='.repeat(pad); const bin = atob(s); const out = new Uint8Array(bin.length);
-    for (let i=0;i<bin.length;i++) out[i] = bin.charCodeAt(i); return out;
+    if (typeof s !== 'string' || s.length === 0){
+      throw new Error('b64uToBytes: input ei ole kelvollinen merkkijono');
+    }
+    const normalized = s.replace(/-/g,'+').replace(/_/g,'/');
+    const pad = (4 - normalized.length % 4) % 4;
+    const padded = normalized + '='.repeat(pad);
+    const bin = atob(padded);
+    const out = new Uint8Array(bin.length);
+    for (let i=0;i<bin.length;i++) out[i] = bin.charCodeAt(i);
+    return out;
   }
   async function decryptAndUse(k, iv, ct){
     try {
@@ -184,7 +205,7 @@
 </div>
 <div class="list" id="out" aria-live="polite"></div>
 
-<script src="https://cdn.jsdelivr.net/npm/tz-lookup@6.1.25/dist/tz.js"></script>
+<script src="https://unpkg.com/tz-lookup@6.1.25/dist/tz.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/suncalc@1.9.0/suncalc.min.js"></script>
 
 <script type="module">
@@ -269,7 +290,9 @@ async function fetchAndDecryptLocation(token, keyB64u){
   }
 
   const { v, iv, ct } = payload;
-  if (v !== 1){
+  const version = typeof v === 'string' ? parseInt(v, 10) : v;
+  if (!Number.isFinite(version) || version !== 1){
+    console.error('Tuntematon sijaintipaketin versio. Vastaanotettu paketti:', payload);
     throw new Error('Tuntematon sijaintipaketin versio.');
   }
   if (typeof iv !== 'string' || typeof ct !== 'string'){


### PR DESCRIPTION
## Summary
- swap the tz-lookup script to an unpkg-hosted build to avoid MIME blocking
- validate required token/key URL parameters and harden base64url decoding against missing values
- accept numeric or string location package versions and log unexpected payloads for debugging

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e03c0ebd248329a268b8a797ab2cca