### PR TITLE
Move tusinapaja backlog to docs

### DIFF
--- a/docs/tusinapaja-backlog.md
+++ b/docs/tusinapaja-backlog.md
@@ -1,0 +1,7 @@
+# Tusinapaja backlog
+
+## Tonttien työlista (palaverin jatkotoimet)
+
+1. Yhtenäistä pääselitteen kirjainkoko niin, että `lowercaseMainDescription` ajetaan kaikissa vaiheissa ilman päivä-vaiherajausta, ja varmista samalla, ettei tyhjät tai HTML-elementillä alkavat selitteet muutu.
+2. Selvitä nousua edeltävien kuivien tuntien käsittely: kun hämärävaihe ei enää päädy päätekstiksi, varmista että kuivan sään kuvaus nostaa ensimmäisen kirjaimen isoksi ja ettei hämärän CSS-yläsuuraus laukea vahingossa.
+3. Päivitä testisuunnitelma kattamaan sumu-, sade- ja kuivatapaukset sekä aurinkotapahtumien molemmat kieliasut, jotta kirjaimiston poikkeamat eivät palaa jatkokehityksessä.

--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -145,18 +145,7 @@
 
 <script type="module">
 /* --------- perusinfra & virheet näkyviin --------- */
-/* --------- tonttien työlista (palaverin jatkotoimet) --------- */
-/*
-1. Yhtenäistä pääselitteen kirjainkoko niin, että `lowercaseMainDescription`
-   ajetaan kaikissa vaiheissa ilman päivä-vaiherajausta, ja varmista samalla,
-   ettei tyhjät tai HTML-elementillä alkavat selitteet muutu.
-2. Selvitä nousua edeltävien kuivien tuntien käsittely: kun hämärävaihe ei enää
-   päädy päätekstiksi, varmista että kuivan sään kuvaus nostaa ensimmäisen
-   kirjaimen isoksi ja ettei hämärän CSS-yläsuuraus laukea vahingossa.
-3. Päivitä testisuunnitelma kattamaan sumu-, sade- ja kuivatapaukset sekä
-   aurinkotapahtumien molemmat kieliasut, jotta kirjaimiston poikkeamat eivät
-   palaa jatkokehityksessä.
-*/
+/* backlog: docs/tusinapaja-backlog.md */
 const out = document.getElementById('out');
 
 function prependError(message){


### PR DESCRIPTION
## Summary
- move the tusinapaja backlog into a new markdown document under docs/
- replace the inline backlog comment in tusinapaja.html with a pointer to the new document

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e072eb2cc48329a6cc484c939d60ab