### PR TITLE
Update tusinapaja error guidance for hash parameters

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -2076,7 +2076,7 @@ function renderHourlyModel(model){
 (async function(){
   scrollTo(0,1); setTimeout(()=>scrollTo(0,1),150);
   if (LAT_STR == null || LON_STR == null || !Number.isFinite(LAT) || !Number.isFinite(LON)){
-    out.innerHTML = `<div class="err">Puuttuvat tai virheelliset koordinaatit. Käytä:<br><code>?lat=60.1699&lon=24.9384</code></div>`;
+    out.innerHTML = `<div class="err">Puuttuvat tai virheelliset koordinaatit. Käytä sijaintilinkkiä, joka sisältää hash-parametrit (#t ja #k), esim.:<br><code>tusinapaja.html#t=…&k=…</code></div>`;
     return;
   }
 


### PR DESCRIPTION
## Summary
- update the tusinapaja missing-coordinate error message to point to the hash-based location link format

## Testing
- manual: opened tusinapaja.html without parameters to confirm the updated message renders and layout remains intact

------
https://chatgpt.com/codex/tasks/task_e_68e072fcbac883298d823a77f5c27366