### PR TITLE
Add Odotushuone minimal waiting room app

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.android.application' version '8.3.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.22' apply false
 }
 
 task clean(type: Delete) {

--- a/android/odotushuone/build.gradle
+++ b/android/odotushuone/build.gradle
@@ -1,0 +1,39 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'fi.tusinasaa.odotushuone'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'fi.tusinasaa.odotushuone'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+        }
+    }
+
+    buildFeatures {
+        buildConfig false
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+}

--- a/android/odotushuone/src/main/AndroidManifest.xml
+++ b/android/odotushuone/src/main/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:label="Odotushuone"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Odotushuone">
+        <activity
+            android:name="fi.tusinasaa.odotushuone.MainActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"
+            android:launchMode="singleTask"
+            android:noHistory="true"
+            android:resizeableActivity="false"
+            android:screenOrientation="portrait">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/odotushuone/src/main/java/fi/tusinasaa/odotushuone/MainActivity.kt
+++ b/android/odotushuone/src/main/java/fi/tusinasaa/odotushuone/MainActivity.kt
@@ -1,0 +1,46 @@
+package fi.tusinasaa.odotushuone
+
+import android.app.Activity
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+
+class MainActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        window.setBackgroundDrawable(ColorDrawable(Color.BLACK))
+        hideSystemUi()
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            hideSystemUi()
+        }
+    }
+
+    private fun hideSystemUi() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+            val controller = window.insetsController ?: return
+            controller.hide(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
+            controller.systemBarsBehavior =
+                WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        } else {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_FULLSCREEN
+                )
+        }
+    }
+}

--- a/android/odotushuone/src/main/res/values/themes.xml
+++ b/android/odotushuone/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<resources>
+    <style name="Theme.Odotushuone" parent="@android:style/Theme.DeviceDefault.NoActionBar">
+        <item name="android:windowBackground">@android:color/black</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -16,3 +16,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "TusinaSaaKotkavuori"
 include(":app")
+include(":odotushuone")


### PR DESCRIPTION
## Summary
- add a standalone Odotushuone Android application module that renders an immersive black screen
- configure the new module with the required manifest flags, minimal theme, and single-task activity behaviour
- enable the Kotlin Android Gradle plugin for the project to support the framework-based Kotlin activity implementation

## Testing
- `./gradlew --no-daemon --console=plain :odotushuone:assembleDebug` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e39edd85988329812c091b685c53c2