### PR TITLE
Keep Odotushuone activity open until user exits

### DIFF
--- a/android/odotushuone/src/main/AndroidManifest.xml
+++ b/android/odotushuone/src/main/AndroidManifest.xml
@@ -11,9 +11,7 @@
             android:name="fi.tusinasaa.odotushuone.MainActivity"
             android:exported="true"
             android:excludeFromRecents="true"
-            android:finishOnTaskLaunch="true"
             android:launchMode="singleTask"
-            android:noHistory="true"
             android:resizeableActivity="false"
             android:screenOrientation="portrait">
             <intent-filter>


### PR DESCRIPTION
## Summary
- remove automatic finish flags from the Odotushuone activity so it stays visible until the user leaves it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3aab63cf08329902c9889a4253de1