### PR TITLE
Render waiting room on a dedicated layout

### DIFF
--- a/android/odotushuone/src/main/AndroidManifest.xml
+++ b/android/odotushuone/src/main/AndroidManifest.xml
@@ -11,9 +11,7 @@
             android:name="fi.tusinasaa.odotushuone.MainActivity"
             android:exported="true"
             android:excludeFromRecents="true"
-            android:finishOnTaskLaunch="true"
             android:launchMode="singleTask"
-            android:noHistory="true"
             android:resizeableActivity="false"
             android:screenOrientation="portrait">
             <intent-filter>

--- a/android/odotushuone/src/main/java/fi/tusinasaa/odotushuone/MainActivity.kt
+++ b/android/odotushuone/src/main/java/fi/tusinasaa/odotushuone/MainActivity.kt
@@ -1,19 +1,19 @@
 package fi.tusinasaa.odotushuone
 
 import android.app.Activity
-import android.graphics.Color
-import android.graphics.drawable.ColorDrawable
 import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsController
+import android.view.WindowManager
 
 class MainActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        window.setBackgroundDrawable(ColorDrawable(Color.BLACK))
+        setContentView(R.layout.activity_main)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         hideSystemUi()
     }
 

--- a/android/odotushuone/src/main/res/layout/activity_main.xml
+++ b/android/odotushuone/src/main/res/layout/activity_main.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    android:keepScreenOn="true" />


### PR DESCRIPTION
## Summary
- render the waiting room activity from an explicit full-screen layout so Android keeps the task alive
- keep the display awake via the window flag to avoid the screen blanking unexpectedly

## Testing
- :odotushuone:assembleDebug --console=plain --no-daemon *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aab63cf08329902c9889a4253de1