### PR TITLE
Add Ouroboros Compose timer Android module

### DIFF
--- a/android/ouroboros/README.md
+++ b/android/ouroboros/README.md
@@ -1,0 +1,15 @@
+# Ouroboros (Android)
+
+Ouroboros on Jetpack Compose -pohjainen erillinen Android-sovellus, joka tarjoaa
+22 minuutin ja 22 sekunnin mittaisen rauhoittumisajastimen. Käyttöliittymä on
+sijoitettu täysin Composeen ilman XML- tai WebView-kerroksia.
+
+## Ohjaus
+
+- **Napautus:** käynnistää, pysäyttää tai jatkaa ajastinta.
+- **Tuplanapautus:** nollaa kuluneen ajan ja aloittaa uuden kierroksen.
+- **Pitkä painallus:** palauttaa ajastimen lepotilaan ilman uutta käynnistystä.
+
+Sovellus pitää näytön hereillä, piilottaa järjestelmäpalkit ja lukitsee
+suunnan pystyasentoon. Viimeistelyvaihe näkyy kahden sekunnin ajan ennen kuin
+ajastin palaa lepotilaan.

--- a/android/ouroboros/build.gradle
+++ b/android/ouroboros/build.gradle
@@ -1,0 +1,67 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'fi.ouroboros.android'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'fi.ouroboros.android'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+
+    buildFeatures {
+        compose true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.8'
+    }
+
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/{AL2.0,LGPL2.1}'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.13.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.8.2'
+
+    def composeBom = platform('androidx.compose:compose-bom:2024.04.01')
+    implementation composeBom
+    androidTestImplementation composeBom
+
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    implementation 'androidx.compose.material3:material3'
+
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+}

--- a/android/ouroboros/proguard-rules.pro
+++ b/android/ouroboros/proguard-rules.pro
@@ -1,0 +1,1 @@
+# No additional rules required yet.

--- a/android/ouroboros/src/main/AndroidManifest.xml
+++ b/android/ouroboros/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="false"
+        android:icon="@android:drawable/sym_def_app_icon"
+        android:label="@string/app_name"
+        android:supportsRtl="false"
+        android:theme="@style/Theme.Ouroboros">
+        <activity
+            android:name="fi.ouroboros.android.MainActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:windowSoftInputMode="stateHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/ouroboros/src/main/java/fi/ouroboros/android/MainActivity.kt
+++ b/android/ouroboros/src/main/java/fi/ouroboros/android/MainActivity.kt
@@ -1,0 +1,283 @@
+package fi.ouroboros.android
+
+import android.os.Build
+import android.os.Bundle
+import android.os.SystemClock
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+import android.view.WindowManager
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import fi.ouroboros.android.ui.theme.OuroborosAccent
+import fi.ouroboros.android.ui.theme.OuroborosMute
+import fi.ouroboros.android.ui.theme.OuroborosTheme
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+private const val DURATION_MS = (22 * 60 + 22) * 1000L
+
+private enum class TimerState {
+    Idle,
+    Running,
+    Paused,
+    Finishing
+}
+
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        hideSystemUi()
+        setContent {
+            OuroborosTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    OuroborosTimer()
+                }
+            }
+        }
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            hideSystemUi()
+        }
+    }
+
+    private fun hideSystemUi() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setDecorFitsSystemWindows(false)
+            val controller = window.insetsController ?: return
+            controller.hide(WindowInsets.Type.statusBars() or WindowInsets.Type.navigationBars())
+            controller.systemBarsBehavior =
+                WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        } else {
+            @Suppress("DEPRECATION")
+            window.decorView.systemUiVisibility = (
+                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY or
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
+                    View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN or
+                    View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or
+                    View.SYSTEM_UI_FLAG_FULLSCREEN
+                )
+        }
+    }
+}
+
+@Composable
+private fun OuroborosTimer() {
+    var state by rememberSaveable { mutableStateOf(TimerState.Idle) }
+    var elapsedMs by rememberSaveable { mutableStateOf(0L) }
+    val haptics = LocalHapticFeedback.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE && state == TimerState.Running) {
+                state = TimerState.Paused
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(state == TimerState.Running) {
+        if (state != TimerState.Running) return@LaunchedEffect
+        var lastTick = SystemClock.uptimeMillis()
+        while (isActive && state == TimerState.Running) {
+            delay(16L)
+            val now = SystemClock.uptimeMillis()
+            val delta = now - lastTick
+            lastTick = now
+            elapsedMs = (elapsedMs + delta).coerceIn(0L, DURATION_MS)
+            if (elapsedMs >= DURATION_MS) {
+                state = TimerState.Finishing
+            }
+        }
+    }
+
+    LaunchedEffect(state) {
+        if (state == TimerState.Finishing) {
+            delay(2000L)
+            elapsedMs = 0L
+            state = TimerState.Idle
+        }
+    }
+
+    val progress = (elapsedMs.toFloat() / DURATION_MS.toFloat()).coerceIn(0f, 1f)
+    val remainingMs = (DURATION_MS - elapsedMs).coerceAtLeast(0L)
+    val remainingSecondsTotal = ((remainingMs + 999L) / 1000L).toInt()
+    val minutes = remainingSecondsTotal / 60
+    val seconds = remainingSecondsTotal % 60
+
+    val statusText = when (state) {
+        TimerState.Idle -> stringResource(R.string.timer_idle)
+        TimerState.Running -> stringResource(R.string.timer_running)
+        TimerState.Paused -> stringResource(R.string.timer_paused)
+        TimerState.Finishing -> stringResource(R.string.timer_finishing)
+    }
+
+    val hint = stringResource(R.string.timer_hint)
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+            .detectTimerGestures(
+                state = state,
+                onTap = {
+                    when (state) {
+                        TimerState.Idle -> {
+                            elapsedMs = 0L
+                            state = TimerState.Running
+                            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        }
+                        TimerState.Running -> {
+                            state = TimerState.Paused
+                            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        }
+                        TimerState.Paused -> {
+                            state = TimerState.Running
+                            haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                        }
+                        TimerState.Finishing -> Unit
+                    }
+                },
+                onDoubleTap = {
+                    if (state != TimerState.Idle) {
+                        elapsedMs = 0L
+                        state = TimerState.Running
+                        haptics.performHapticFeedback(HapticFeedbackType.TextHandleMove)
+                    }
+                },
+                onLongPress = {
+                    if (state != TimerState.Idle) {
+                        state = TimerState.Idle
+                        elapsedMs = 0L
+                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                    }
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                TimerRing(progress = progress, diameter = 260.dp)
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Text(
+                        text = "%02d:%02d".format(minutes, seconds),
+                        style = MaterialTheme.typography.displayMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = 72.sp
+                        ),
+                        color = MaterialTheme.colorScheme.onBackground,
+                        textAlign = TextAlign.Center
+                    )
+                    Crossfade(targetState = statusText, label = "status") { text ->
+                        Text(
+                            text = text,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+            }
+            Text(
+                text = hint,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+        }
+    }
+}
+
+private fun Modifier.detectTimerGestures(
+    state: TimerState,
+    onTap: () -> Unit,
+    onDoubleTap: () -> Unit,
+    onLongPress: () -> Unit
+): Modifier = pointerInput(state) {
+    detectTapGestures(
+        onDoubleTap = { onDoubleTap() },
+        onLongPress = { onLongPress() },
+        onTap = { onTap() }
+    )
+}
+
+@Composable
+private fun TimerRing(progress: Float, diameter: Dp) {
+    Canvas(
+        modifier = Modifier
+            .size(diameter)
+            .clip(CircleShape)
+    ) {
+        val sweep = 360f * progress
+        val strokeWidth = size.minDimension * 0.1f
+        drawCircle(
+            color = OuroborosMute,
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+        )
+        drawArc(
+            color = OuroborosAccent,
+            startAngle = -90f,
+            sweepAngle = sweep,
+            useCenter = false,
+            style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+        )
+    }
+}

--- a/android/ouroboros/src/main/java/fi/ouroboros/android/ui/theme/Color.kt
+++ b/android/ouroboros/src/main/java/fi/ouroboros/android/ui/theme/Color.kt
@@ -1,0 +1,14 @@
+package fi.ouroboros.android.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val OuroborosPrimary = Color(0xFF4DD0E1)
+val OuroborosOnPrimary = Color(0xFF002022)
+val OuroborosSecondary = Color(0xFF80CBC4)
+val OuroborosOnSecondary = Color(0xFF00201A)
+val OuroborosBackground = Color(0xFF000000)
+val OuroborosOnBackground = Color(0xFFE0F7FA)
+val OuroborosSurface = Color(0xFF001F24)
+val OuroborosOnSurface = Color(0xFFB2EBF2)
+val OuroborosAccent = Color(0xFF00BCD4)
+val OuroborosMute = Color(0xFF1C3138)

--- a/android/ouroboros/src/main/java/fi/ouroboros/android/ui/theme/OuroborosTheme.kt
+++ b/android/ouroboros/src/main/java/fi/ouroboros/android/ui/theme/OuroborosTheme.kt
@@ -1,0 +1,25 @@
+package fi.ouroboros.android.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColors = darkColorScheme(
+    primary = OuroborosPrimary,
+    onPrimary = OuroborosOnPrimary,
+    secondary = OuroborosSecondary,
+    onSecondary = OuroborosOnSecondary,
+    background = OuroborosBackground,
+    onBackground = OuroborosOnBackground,
+    surface = OuroborosSurface,
+    onSurface = OuroborosOnSurface,
+)
+
+@Composable
+fun OuroborosTheme(content: @Composable () -> Unit) {
+    MaterialTheme(
+        colorScheme = DarkColors,
+        typography = MaterialTheme.typography,
+        content = content
+    )
+}

--- a/android/ouroboros/src/main/res/values/strings.xml
+++ b/android/ouroboros/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Ouroboros</string>
+    <string name="timer_idle">Valmis aloittamaan</string>
+    <string name="timer_running">Kierros käynnissä</string>
+    <string name="timer_paused">Tauolla</string>
+    <string name="timer_finishing">Viimeistely</string>
+    <string name="timer_hint">napauta = käynnistä/pysäytä, tuplanapauta = uusintakäynnistys, pitkä painallus = nollaa</string>
+</resources>

--- a/android/ouroboros/src/main/res/values/themes.xml
+++ b/android/ouroboros/src/main/res/values/themes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Ouroboros" parent="Theme.Material3.Dark.NoActionBar">
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:navigationBarColor">@android:color/black</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+</resources>

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -17,3 +17,4 @@ dependencyResolutionManagement {
 rootProject.name = "TusinaSaaKotkavuori"
 include(":app")
 include(":odotushuone")
+include(":ouroboros")


### PR DESCRIPTION
## Summary
- add a new `ouroboros` Android application module that hosts a Jetpack Compose timer experience
- implement the Ouroboros activity, theme, resources, and documentation for the 22:22 gesture-controlled countdown
- register the module in the shared Android settings so it can be built alongside the existing apps

## Testing
- ./gradlew :ouroboros:assembleDebug *(fails: Android SDK is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4504c9f108329823a554c70205b68