### PR TITLE
Clarify Ouroboros assets and ring rendering

### DIFF
--- a/android/ouroboros/README.md
+++ b/android/ouroboros/README.md
@@ -20,3 +20,12 @@ Sovellus etsii kellon sointia tiedostosta `android/ouroboros/src/main/res/raw/ke
 Binaaritiedostoja ei säilytetä tässä repossa, joten lisää äänitiedosto
 paikallisesti kyseiseen kansioon (tai korvaa polku haluamallasi äänellä) ennen
 kuin ajat sovelluksen.
+
+## Assetit ja visuaalinen rakenne
+
+- Compose-pohjainen sovellus ei käytä SVG-kuvaa ajan etenemisen rinkulaan, vaan
+  piirtää taustan ja etenemiskaaren `Canvas`-komponentilla
+  (`TimerRing`-funktio `MainActivity.kt`:ssä).
+- WebView-pohjainen **Odotushuone**-moduuli tarvitsee tiedoston
+  `android/odotushuone/src/main/assets/ouroboros.svg`, joten jos testaat myös
+  sitä, varmista että kyseinen tiedosto löytyy luomastasi `assets`-kansiosta.


### PR DESCRIPTION
## Summary
- document that the Compose-based Ouroboros timer renders its ring via Canvas instead of an SVG asset
- note that only the Odotushuone module requires the ouroboros.svg file inside its assets directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e457260afc8329b6c735b37527f70e