### PR TITLE
Prevent twilight tags when sunrise minute blocks main

### DIFF
--- a/tusinapaja.html
+++ b/tusinapaja.html
@@ -1551,7 +1551,7 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
   let startTag = null;
   let startKey = null;
   let suppressedTwilightEntry = null;
-  if (tw.phase && TWILIGHT_PHASES.has(tw.phase) && tw.phaseStart instanceof Date){
+  if (twilightMainAllowed && tw.phase && TWILIGHT_PHASES.has(tw.phase) && tw.phaseStart instanceof Date){
     const phaseStart = tw.phaseStart;
     const hhmm = fmtHM(phaseStart);
     const minutes = phaseStart.getMinutes();
@@ -1608,7 +1608,7 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
     tags.push(startTag);
     if (startKey) twilightState.announced.add(startKey);
   }
-  if (tw.withinChange){
+  if (twilightMainAllowed && tw.withinChange){
     const preferNextLabel = !!suppressedTwilightEntry || !precipish;
     let label = preferNextLabel ? nextLabelFor(tw.withinChange.to) : null;
     if (!label){
@@ -1700,7 +1700,7 @@ function decorateDescription(baseText, tw, { precipish, hourStart }){
       const key = `${tw.withinChange.to}-${tw.withinChange.at.getTime()}`;
       twilightState.announced.add(key);
     }
-  } else if (phaseMain){
+  } else if (twilightMainAllowed && phaseMain){
     if (precipish || !twilightMain) tags.push({ text: phaseMain, italic: true });
   }
 


### PR DESCRIPTION
## Summary
- ensure twilight decorations only render when the sunrise/sunset minute allows twilight as a main description, preventing impossible twilight add-ons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f550bba9b4832987415419ae6afd89